### PR TITLE
fix: check if false/null was returned from json_decode before trying to access a property on it

### DIFF
--- a/src/Dotmailer/Exception.php
+++ b/src/Dotmailer/Exception.php
@@ -42,6 +42,11 @@ class Exception extends \Exception
         if ($key == 'api_response') {
             if (!empty($this->response)) {
                 $body = json_decode($this->response->getBody());
+                
+                if (!$body) {
+                    return null;
+                }
+                
                 return $body->message;
             } else {
                 return null;

--- a/src/Dotmailer/Exception.php
+++ b/src/Dotmailer/Exception.php
@@ -43,7 +43,7 @@ class Exception extends \Exception
             if (!empty($this->response)) {
                 $body = json_decode($this->response->getBody());
                 
-                if (!$body) {
+                if (!$body || !isset($body->message)) {
                     return null;
                 }
                 


### PR DESCRIPTION
`vendor/leewillis77/dotmailer-api/src/Dotmailer/Exception.php on line 45` fixes some errors you sometimes get when dotmailer either returns junk or a timeout/partial response
