### PR TITLE
Support symfony/yaml to support Laravel 5.X versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "~3.7",
-        "symfony/yaml": "~2.4"
+        "guzzlehttp/guzzle": "~3.7",
+        "symfony/yaml": "~2.4|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Added support for `symfony/yaml` version 3 for support with Laravel & Lumen 5.X

@mattclements