### PR TITLE
Add branch aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,11 @@
         "psr-0": {
             "Dotmailer\\": "src"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-dev": "1.0.x-dev",
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Add branch aliases so that the library can be required without relying on `dev-master` and `dev-dev` releases.