### PR TITLE
Add AbstractConfig to allow for different methods of adding configuration

### DIFF
--- a/src/Dotmailer/AbstractConfig.php
+++ b/src/Dotmailer/AbstractConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Dotmailer;
+
+abstract class AbstractConfig
+{
+    /**
+     * @var array
+     */
+    protected $config;
+
+    public function __get($key)
+    {
+        if (isset($this->config[$key])) {
+            return $this->config[$key];
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/Dotmailer/Config.php
+++ b/src/Dotmailer/Config.php
@@ -4,22 +4,11 @@ namespace Dotmailer;
 
 use Symfony\Component\Yaml\Parser;
 
-class Config
+class Config extends AbstractConfig
 {
-    protected $config;
-
     public function __construct($config_file)
     {
         $parser = new Parser();
         $this->config = $parser->parse(file_get_contents($config_file));
-    }
-
-    public function __get($key)
-    {
-        if (isset($this->config[$key])) {
-            return $this->config[$key];
-        } else {
-            return null;
-        }
     }
 }

--- a/src/Dotmailer/Request/ContactRequest.php
+++ b/src/Dotmailer/Request/ContactRequest.php
@@ -2,7 +2,7 @@
 
 namespace Dotmailer\Request;
 
-use Dotmailer\Config;
+use Dotmailer\AbstractConfig;
 use Dotmailer\Entity\Contact;
 use Dotmailer\Entity\ContactSuppression;
 use Dotmailer\Entity\Resubscription;
@@ -10,12 +10,11 @@ use Dotmailer\Collection\AddressbookCollection;
 use Dotmailer\Collection\ContactCollection;
 use Dotmailer\Collection\SuppressedContactCollection;
 
-
 class ContactRequest
 {
     private $request;
 
-    public function __construct(Config $config)
+    public function __construct(AbstractConfig $config)
     {
         $this->request = new Request($config);
         $this->request->setEndpoint('contacts');

--- a/src/Dotmailer/Request/Request.php
+++ b/src/Dotmailer/Request/Request.php
@@ -2,8 +2,8 @@
 
 namespace Dotmailer\Request;
 
+use Dotmailer\AbstractConfig;
 use Guzzle\Http\Client;
-use Dotmailer\Config;
 use Dotmailer\Exception;
 
 class Request
@@ -12,7 +12,7 @@ class Request
     private $args;
     protected $endpoint = 'https://api.dotmailer.com/v2/';
 
-    public function __construct(Config $config)
+    public function __construct(AbstractConfig $config)
     {
         $this->config = $config;
         $this->client = new Client();


### PR DESCRIPTION
I'm using this library within a Drupal 8 module to push contacts from a form to Dotmailer. However in the current implementation, the only way to add configuration such as the username and password is within a config.yml file (e.g. https://github.com/leewillis77/dotmailer-api/blob/master/config/config.yml.sample). In this case, I needed to be able to set the configuration within Drupal's own configuration system so it can be editable by the client via a settings form within the admin UI.

As this is not possible with the current code, I've added a `AbstractConfig` class to my forked version which I can then extend, and likewise the current `Config` class can then extend. This PR adds the `AbstractConfig` class and updates some of the existing `Config` typehints to `AbstractConfig`.

I have this currently working in production using my forked version via Composer, and feel that this could also be useful for others with a similar use-case with a different CMS or framework.

For reference, here is my implementation of the `DrupalConfig` class that I've created that extends `AbstractConfig`, gets the details from Drupal's config system then assigns the value to `$this->config` - the same as it does currently.

```
<?php

namespace Drupal\microserve_newsletter\Dotmailer\Config;

use Dotmailer\AbstractConfig;

class DrupalConfig extends AbstractConfig {

  public function __construct() {
    $config = \Drupal::config('microserve_newsletter.settings');

    $username = $config->get('dotmailer.username');
    $password = $config->get('dotmailer.password');

    $this->config = compact('username', 'password');
  }

}
```